### PR TITLE
add Types Folder to Export-RootModule

### DIFF
--- a/codaamok.build/Public/Build/Export-RootModule.ps1
+++ b/codaamok.build/Public/Build/Export-RootModule.ps1
@@ -20,7 +20,7 @@ function Export-RootModule {
 
     $null = New-Item -Path $RootModule -ItemType "File" -Force
 
-    foreach ($FunctionType in "Private","Public") {
+    foreach ($FunctionType in "Private","Public","Types") {
         '#region {0} functions' -f $FunctionType | Add-Content -Path $RootModule
 
         $Files = @(Get-ChildItem $DevModulePath\$FunctionType -Filter *.ps1 -Recurse)


### PR DESCRIPTION
i want to use your build script for this Repo:
https://github.com/baramundisoftware/PS-bConnect/tree/master/bConnect
which is using custom Types.

The Build process failed because of the types that are missing
